### PR TITLE
Set up Cursor Cloud dev environment + add Brio-Wu MHD shock tube

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+PHRIKE is a Python pseudo-spectral CFD/MHD solver exposed as a CLI (`phrike`) and a
+Python API (`phrike.run_simulation`). There are no web servers, databases, or
+long-running background services — simulations run as one-off processes.
+
+### Environment
+- Dependencies are installed into a virtualenv at `.venv/` (gitignored). The startup
+  update script creates it and runs `pip install -e ".[dev]"`.
+- Run tools via the venv without activating, e.g. `.venv/bin/phrike ...`,
+  `.venv/bin/pytest`, `.venv/bin/ruff ...` (or `source .venv/bin/activate` first).
+- `ffmpeg` is available system-wide and is only needed for `--video` output.
+
+### Running simulations (the core functionality)
+- Standard run: `.venv/bin/phrike <problem> --config configs/<file>.yaml`
+  (e.g. `.venv/bin/phrike sod --config configs/sod.yaml`). Problems and matching
+  configs are listed by `.venv/bin/phrike --help` and live in `configs/`.
+- Outputs (`.npz` snapshots, `.png` field plots, `.mp4` videos) are written to
+  `outputs/` (gitignored), overridable with `--outdir`.
+- Video is off by default; enable with `--video`. Note: several configs (e.g.
+  `configs/sod.yaml`) default `video.codec` to `h264_videotoolbox`, which is
+  macOS-only. On Linux pass `--video-codec libx264`.
+- GPU/`--backend torch` requires the optional `[torch]` extra (not installed by
+  default); the default `numpy` CPU backend works out of the box.
+
+### Lint / test caveats
+- Lint: `.venv/bin/ruff check phrike/` runs but the existing codebase currently has
+  many pre-existing violations (it exits non-zero). This is the repo's current state,
+  not a setup problem.
+- Tests: there is no real test suite. `pyproject.toml` excludes a `tests/` dir that
+  does not exist, and the root-level `test_*.py` files are standalone scripts (not
+  pytest-compatible), so `.venv/bin/pytest` errors on collection. Validate changes by
+  running actual simulations via the CLI/API instead.

--- a/configs/briowu.yaml
+++ b/configs/briowu.yaml
@@ -1,0 +1,76 @@
+# 1D Brio-Wu MHD shock tube (Brio & Wu 1988), periodic (Fourier) basis.
+#   python -m phrike briowu --config configs/briowu.yaml
+#   python -m phrike briowu --config configs/briowu.yaml --video --video-codec libx264
+problem: briowu
+
+grid:
+  N: 512
+  Lx: 1.0
+  x0: 0.5                 # discontinuity location
+  dealias: true
+  precision: double
+
+physics:
+  gamma: 2.0
+  mhd:
+    enabled: true
+    resistivity: 1.0e-3     # eta — small explicit dissipation to stabilise shocks
+    viscosity: 1.0e-3       # nu
+    divergence_clean: projection
+    project_each_substage: true
+
+integration:
+  t0: 0.0
+  t_end: 0.1                # standard Brio-Wu final time on [0,1]
+  cfl: 0.3
+  scheme: rk4
+  output_interval: 0.005    # -> 21 frames for the video
+  checkpoint_interval: 0.0
+  spectral_filter:
+    enabled: true
+    p: 8
+    alpha: 36.0
+
+# Brio-Wu Riemann initial condition (primitive variables)
+initial_conditions:
+  Bx: 0.75                  # uniform normal field (constant in 1D)
+  left:
+    rho: 1.0
+    ux: 0.0
+    uy: 0.0
+    uz: 0.0
+    p: 1.0
+    By: 1.0
+    Bz: 0.0
+  right:
+    rho: 0.125
+    ux: 0.0
+    uy: 0.0
+    uz: 0.0
+    p: 0.1
+    By: -1.0
+    Bz: 0.0
+
+io:
+  outdir: outputs/briowu
+
+monitoring:
+  enabled: true
+  step_interval: 100
+  include_conservation: true
+  include_timestep: true
+  include_time: true
+
+video:
+  fps: 30
+  width: 1920
+  height: 1080
+  scale: 1.0
+  frame_dpi: 150
+  quality: high
+  codec: libx264            # Linux-friendly (configs default elsewhere to macOS h264_videotoolbox)
+  crf: 23
+  preset: medium
+  pix_fmt: yuv420p
+  profile: high
+  level: "4.1"

--- a/phrike/problems/problem_list/briowu1d.py
+++ b/phrike/problems/problem_list/briowu1d.py
@@ -1,0 +1,194 @@
+"""1D Brio-Wu MHD shock tube — classic coplanar MHD Riemann problem.
+
+Brio & Wu (1988). Standard setup on ``[0, Lx]`` with a discontinuity at ``x0``
+and ``gamma = 2``:
+
+    left  (x < x0):  rho = 1.0,   u = 0, p = 1.0, By = +1.0
+    right (x >= x0): rho = 0.125, u = 0, p = 0.1, By = -1.0
+    Bx = 0.75 (constant),  Bz = 0
+
+The solution develops the characteristic Brio-Wu structure: a fast rarefaction,
+a slow compound wave, a contact discontinuity, a slow shock, and a fast
+rarefaction. ``Bx`` is constant in 1D (the solenoidal constraint dBx/dx = 0), so
+the fast/slow waves only modulate the transverse field ``By``.
+
+This problem uses a periodic (Fourier) basis. The run time is kept short enough
+that the waves launched from ``x0`` do not interact with the waves launched from
+the periodic image of the discontinuity at the domain edge, so the central
+structure matches the standard (open-boundary) Brio-Wu reference solution.
+Shocks are stabilised by the spectral filter together with a small explicit
+resistivity/viscosity (``physics.mhd.resistivity`` / ``.viscosity``).
+"""
+
+import os
+from typing import Optional, Dict, Any
+
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from phrike.grid import Grid1D
+from phrike.equations import MHDEquations1D
+from phrike.solver import SpectralSolverMHD1D
+from phrike.io import save_solution_snapshot
+from ..base import BaseProblem
+
+
+def brio_wu_shock_tube(
+    x,
+    x0: float,
+    left: Dict[str, float],
+    right: Dict[str, float],
+    Bx: float,
+    gamma: float,
+):
+    """Return the conservative MHD state for the Brio-Wu initial condition.
+
+    ``left`` / ``right`` dictionaries provide the primitive variables on each
+    side of ``x0``: ``rho``, ``p``, ``By`` (required) and ``ux``, ``uy``, ``uz``,
+    ``Bz`` (optional, default 0). ``Bx`` is uniform across the domain.
+    """
+    is_torch = hasattr(x, "cpu")
+
+    def _g(side: Dict[str, float], key: str, default: float = 0.0) -> float:
+        return float(side.get(key, default))
+
+    if is_torch:
+        import torch
+
+        def step(vl: float, vr: float):
+            return torch.where(
+                x < x0,
+                torch.tensor(float(vl), dtype=x.dtype, device=x.device),
+                torch.tensor(float(vr), dtype=x.dtype, device=x.device),
+            )
+
+        Bx_field = torch.full_like(x, float(Bx))
+    else:
+        def step(vl: float, vr: float):
+            return np.where(x < x0, float(vl), float(vr))
+
+        Bx_field = np.full_like(x, float(Bx))
+
+    rho = step(_g(left, "rho", 1.0), _g(right, "rho", 0.125))
+    ux = step(_g(left, "ux"), _g(right, "ux"))
+    uy = step(_g(left, "uy"), _g(right, "uy"))
+    uz = step(_g(left, "uz"), _g(right, "uz"))
+    p = step(_g(left, "p", 1.0), _g(right, "p", 0.1))
+    By = step(_g(left, "By", 1.0), _g(right, "By", -1.0))
+    Bz = step(_g(left, "Bz"), _g(right, "Bz"))
+
+    eqs = MHDEquations1D(gamma=gamma)
+    return eqs.conservative(rho, ux, uy, uz, p, Bx_field, By, Bz)
+
+
+class BrioWu1DProblem(BaseProblem):
+    """1D Brio-Wu MHD shock tube."""
+
+    def _ic_params(self) -> Dict[str, Any]:
+        icfg = self.config.get("initial_conditions", {})
+        return dict(
+            left=dict(icfg.get("left", {})),
+            right=dict(icfg.get("right", {})),
+            Bx=float(icfg.get("Bx", 0.75)),
+        )
+
+    def create_grid(
+        self, backend: str = "numpy", device: Optional[str] = None, debug: bool = False
+    ) -> Grid1D:
+        N = int(self.config["grid"]["N"])
+        Lx = float(self.config["grid"]["Lx"])
+        dealias = bool(self.config["grid"].get("dealias", True))
+        grid = Grid1D(
+            N=N,
+            Lx=Lx,
+            basis="fourier",
+            dealias=dealias,
+            filter_params=self.filter_config,
+            fft_workers=self.fft_workers,
+            backend=backend,
+            torch_device=device,
+            precision=self.precision,
+            debug=debug,
+        )
+        grid.mhd_config = self.config.get("physics", {}).get("mhd", {})
+        return grid
+
+    def create_equations(self) -> MHDEquations1D:
+        return MHDEquations1D(gamma=self.gamma)
+
+    def create_initial_conditions(self, grid: Grid1D):
+        x0 = float(self.config["grid"].get("x0", 0.5 * grid.Lx))
+        return brio_wu_shock_tube(grid.x, x0=x0, gamma=self.gamma, **self._ic_params())
+
+    def _plot_panels(self, fig, axes, x, rho, ux, uy, p, By, Bx) -> None:
+        panels = (
+            (axes[0, 0], rho, "Density", "b"),
+            (axes[0, 1], p, "Pressure", "m"),
+            (axes[0, 2], By, "By (transverse field)", "purple"),
+            (axes[1, 0], ux, "Velocity x", "g"),
+            (axes[1, 1], uy, "Velocity y", "darkorange"),
+            (axes[1, 2], Bx, "Bx (constant in 1D)", "teal"),
+        )
+        for ax, data, title, color in panels:
+            ax.plot(x, data, color=color, linewidth=1.5)
+            ax.set_xlabel("x")
+            ax.set_title(title)
+            ax.grid(True, alpha=0.3)
+
+    def create_visualization(self, solver, t: float, U) -> None:
+        frames_dir = os.path.join(self.outdir, "frames")
+        os.makedirs(frames_dir, exist_ok=True)
+
+        video_config = self.config.get("video", {})
+        frame_dpi = int(video_config.get("frame_dpi", 150))
+        frame_scale = float(video_config.get("scale", 1.0))
+        figsize = (15 * frame_scale, 8 * frame_scale)
+
+        rho, ux, uy, uz, p, Bx, By, Bz = solver.equations.primitive(U)
+        x = solver.grid.x
+        x, rho, ux, uy, p, Bx, By = self.convert_torch_to_numpy(
+            x, rho, ux, uy, p, Bx, By
+        )
+
+        fig, axes = plt.subplots(2, 3, figsize=figsize, constrained_layout=True)
+        fig.suptitle(f"Brio-Wu MHD shock tube at t={t:.3f}", fontsize=14)
+        self._plot_panels(fig, axes, x, rho, ux, uy, p, By, Bx)
+        fig.savefig(os.path.join(frames_dir, f"frame_{t:08.3f}.png"), dpi=frame_dpi)
+        plt.close(fig)
+
+        snapshot_path = save_solution_snapshot(
+            self.outdir, t, U=U, grid=solver.grid, equations=solver.equations
+        )
+        print(f"Saved snapshot at t={t:.3f}: {snapshot_path}")
+
+    def create_final_visualization(self, solver) -> None:
+        snapshot_path = save_solution_snapshot(
+            self.outdir,
+            solver.t,
+            U=solver.U,
+            grid=solver.grid,
+            equations=solver.equations,
+        )
+        print(f"Saved final snapshot: {snapshot_path}")
+
+        rho, ux, uy, uz, p, Bx, By, Bz = solver.equations.primitive(solver.U)
+        x = solver.grid.x
+        x, rho, ux, uy, p, Bx, By = self.convert_torch_to_numpy(
+            x, rho, ux, uy, p, Bx, By
+        )
+
+        fig, axes = plt.subplots(2, 3, figsize=(15, 8), constrained_layout=True)
+        fig.suptitle(f"Brio-Wu MHD shock tube at t={solver.t:.3f}", fontsize=14)
+        self._plot_panels(fig, axes, x, rho, ux, uy, p, By, Bx)
+        fig.savefig(
+            os.path.join(self.outdir, f"fields_t{solver.t:.3f}.png"),
+            dpi=150,
+            bbox_inches="tight",
+        )
+        plt.close(fig)
+
+    def get_solver_class(self):
+        return SpectralSolverMHD1D

--- a/phrike/problems/register.py
+++ b/phrike/problems/register.py
@@ -15,6 +15,7 @@ from .problem_list.uniform2d import Uniform2DProblem
 from .problem_list.gaussian_wave2d import GaussianWave2DProblem
 from .problem_list.gaussian_wave2d_y import GaussianWave2DYProblem
 from .problem_list.alfven1d import Alfven1DProblem
+from .problem_list.briowu1d import BrioWu1DProblem
 from .problem_list.orszag_tang2d import OrszagTang2DProblem
 from .problem_list.alfven3d import Alfven3DProblem
 from .problem_list.mhd_turb3d import MHDTurb3DProblem
@@ -35,6 +36,7 @@ ProblemRegistry.register("uniform_2d", Uniform2DProblem)
 ProblemRegistry.register("gaussian_wave2d", GaussianWave2DProblem)
 ProblemRegistry.register("gaussian_wave2d_y", GaussianWave2DYProblem)
 ProblemRegistry.register("alfven1d", Alfven1DProblem)
+ProblemRegistry.register("briowu", BrioWu1DProblem)
 ProblemRegistry.register("orszag_tang2d", OrszagTang2DProblem)
 ProblemRegistry.register("alfven3d", Alfven3DProblem)
 ProblemRegistry.register("mhd_turb3d", MHDTurb3DProblem)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Two related pieces of work on this branch:

### 1. Dev environment setup
- Adds `AGENTS.md` with Cursor Cloud specific instructions (venv usage, how to run simulations, video codec caveat on Linux, lint/test caveats).
- Environment uses a virtualenv at `.venv/` with `pip install -e ".[dev]"` (captured in the startup update script, not committed code).

### 2. New problem: 1D Brio-Wu MHD shock tube (periodic BCs)
- Adds `phrike/problems/problem_list/briowu1d.py` (`BrioWu1DProblem`), registered as `briowu`.
- Adds `configs/briowu.yaml` — classic Brio & Wu (1988) coplanar MHD Riemann problem on a periodic (Fourier) basis: `gamma=2`, left `(rho,p,By)=(1,1,+1)`, right `(0.125,0.1,-1)`, uniform `Bx=0.75`, `t_end=0.1`.
- Reuses the existing `MHDEquations1D` / `SpectralSolverMHD1D`; shocks are stabilized by the spectral filter plus a small explicit resistivity/viscosity (`physics.mhd.resistivity`/`.viscosity`).

Run it with:
```
phrike briowu --config configs/briowu.yaml
phrike briowu --config configs/briowu.yaml --video
```

## Verification
- ✅ `phrike briowu --config configs/briowu.yaml` — runs end-to-end; `max|divB|=0` throughout, `Bx` exactly constant at 0.75, mass/momentum conserved to machine precision; small energy/magnetic-energy decay is the expected resistive/viscous dissipation.
- ✅ `phrike briowu --config configs/briowu.yaml --video` — produces a 6-panel evolution video (reviewed: correct Brio-Wu wave structure, no NaN/blow-up).
- ✅ `ruff check phrike/problems/problem_list/briowu1d.py phrike/problems/register.py` — clean.
- ✅ `phrike sod --config configs/sod.yaml` — environment sanity check (from setup).

### Brio-Wu final state (t=0.1)
[Brio-Wu final fields](https://cursor.com/agents/bc-6b274372-87a2-409a-86a3-7c5c695c8eeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbriowu_final_fields.png)

### Brio-Wu evolution
[briowu_simulation.mp4](https://cursor.com/agents/bc-6b274372-87a2-409a-86a3-7c5c695c8eeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbriowu_simulation.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b274372-87a2-409a-86a3-7c5c695c8eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b274372-87a2-409a-86a3-7c5c695c8eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

